### PR TITLE
Allow undefined routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ To setup the Firetail NGINX Module, you will need to modify your `nginx.conf` to
 load_module modules/ngx_firetail_module.so;
 ```
 
-You can then use the `firetail_api_token` directive to provide your Firetail logging API token inside a http block like so:
+You can then configure it using the following directives, which all belong in the `http` block of your NGINX configuration:
 
-```
-  firetail_api_token "YOUR-API-TOKEN";
-```
+| Directive                         | Description                                                  | Example                                                      |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `firetail_api_token`              | Your API token from the FireTail platform                    | `PS-02-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `firetail_url`                    | The URL of the API endpoint the FireTail NGINX module will send logs to. | `https://api.logging.eu-west-1.prod.firetail.app/logs/bulk`  |
+| `firetail_allow_undefined_routes` | If set to `1`, `t`, `T`, `TRUE`, `true`, or `True`, requests to routes not defined in your OpenAPI specification will not be blocked. | `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False` |
 
-See [dev/nginx.conf](./dev/nginx.conf) for an example of this in action.
+See [dev/nginx.conf](./dev/nginx.conf) for an example of these in use.
 
 You should use a module such as the [ngx_http_lua_module](https://github.com/openresty/lua-nginx-module) to avoid placing plaintext credentials in your `nginx.conf`, and instead make use of [system environment variables](https://github.com/openresty/lua-nginx-module#system-environment-variable-support).
 

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -11,6 +11,7 @@ http {
   # You should use lua-nginx-module to pull the API token in from an environment variable here
   firetail_api_token "YOUR-API-TOKEN";
   firetail_url "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk";
+  firetail_allow_undefined_routes "true";
 
   server {
     listen       80;

--- a/src/validator/go.mod
+++ b/src/validator/go.mod
@@ -16,4 +16,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/FireTail-io/firetail-go-lib => github.com/FireTail-io/firetail-go-lib v0.2.1
+replace github.com/FireTail-io/firetail-go-lib => github.com/FireTail-io/firetail-go-lib v0.2.3

--- a/src/validator/go.sum
+++ b/src/validator/go.sum
@@ -1,5 +1,7 @@
 github.com/FireTail-io/firetail-go-lib v0.2.1 h1:Jf3C1mAtCHAHHqSeuaMx6sSRmUS7OjgY4B2nY8XfibU=
 github.com/FireTail-io/firetail-go-lib v0.2.1/go.mod h1:PH4aGBwry6z/3vzXEdcMaxK22E3xqPq2+w2y3FzETj4=
+github.com/FireTail-io/firetail-go-lib v0.2.3 h1:MDWnEpa/cyqc5sfhyHLjSXz8C+510nmHvpVxiOXnFAg=
+github.com/FireTail-io/firetail-go-lib v0.2.3/go.mod h1:PH4aGBwry6z/3vzXEdcMaxK22E3xqPq2+w2y3FzETj4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Describe your changes

Implements using the new `AllowUndefinedRoutes` option in the Go middleware - instead of ignoring its 404 responses - so that response logs reported to the FireTail SaaS platform aren't overwritten with 404s when requests don't match against a route in your OpenAPI spec.

## Issue ticket number and link

https://firetail-io.atlassian.net/browse/FIRE-2898

## Checklist before requesting a review

-   [x] I have resolved any merge conflicts
-   [x] I have run tests locally and they pass
-   [x] I have linted and auto-formatted the code
-   [ ] If there is new or changed functionality, I have added/updated the tests.
-   [ ] If there is new or changed functionality, I have added/updated the documentation.
