### PR TITLE
Disable firetail directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can then configure it using the following directives:
 | --------------------------------- | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | `firetail_api_token`              | `http`     | Your API token from the FireTail platform                    | `PS-02-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
 | `firetail_url`                    | `http`     | The URL of the API endpoint the FireTail NGINX module will send logs to. | `https://api.logging.eu-west-1.prod.firetail.app/logs/bulk`  |
+| `firetail_disable`                | `http`     | Disables Firetail by default. Firetail will only be enabled for locations in which you use the `firetail_enable` directive. | This directive takes no arguments.                           |
 | `firetail_enable`                 | `location` | Use this in every location block for which you want FireTail to be enabled. | This directive takes no arguments.                           |
 | `firetail_allow_undefined_routes` | `http`     | If set to `1`, `t`, `T`, `TRUE`, `true`, or `True`, requests to routes not defined in your OpenAPI specification will not be blocked. | `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False` |
 

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -11,6 +11,7 @@ http {
   # You should use lua-nginx-module to pull the API token in from an environment variable here
   firetail_api_token "YOUR-API-TOKEN";
   firetail_url "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk";
+  firetail_disable;
   firetail_allow_undefined_routes "true";
 
   server {

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -55,22 +55,27 @@ http {
     }
 
     location /proxy/health {
+      firetail_enable;
       proxy_pass http://localhost:80/health;
     }
 
     location /proxy/notfound {
+      firetail_enable;
       proxy_pass http://localhost:80/notexists;
     }
 
     location /proxy/unhealthy {
+      firetail_enable;
       proxy_pass http://localhost:80/unhealth;
     }
   
     location /proxy/profile/alice/comment {
+      firetail_enable;
       proxy_pass http://localhost:80/profile/alice/comment;
     }
 
     location /proxy/profile/bob {
+      firetail_enable;
       proxy_pass http://localhost:80/profile/bob;
     }
   }

--- a/src/nginx_module/access_phase_handler.c
+++ b/src/nginx_module/access_phase_handler.c
@@ -1,6 +1,5 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
-#include "access_phase_handler.h"
 #include "filter_context.h"
 #include "firetail_config.h"
 #include "firetail_module.h"

--- a/src/nginx_module/filter_headers.c
+++ b/src/nginx_module/filter_headers.c
@@ -1,6 +1,6 @@
 #include <ngx_core.h>
+#include <ngx_http.h>
 #include "filter_context.h"
-#include "filter_headers.h"
 #include "firetail_config.h"
 #include "firetail_module.h"
 

--- a/src/nginx_module/filter_response_body.c
+++ b/src/nginx_module/filter_response_body.c
@@ -1,8 +1,7 @@
 #include <ngx_core.h>
-#include <curl/curl.h>
+#include <ngx_http.h>
 #include <json-c/json.h>
 #include "filter_context.h"
-#include "filter_response_body.h"
 #include "firetail_config.h"
 #include "firetail_module.h"
 

--- a/src/nginx_module/firetail_context.c
+++ b/src/nginx_module/firetail_context.c
@@ -41,7 +41,7 @@ void *CreateFiretailConfig(ngx_conf_t *configuration_object) {
   ngx_str_t firetail_url = ngx_string("");
   firetail_config->FiretailApiToken = firetail_api_token;
   firetail_config->FiretailUrl = firetail_url;
-  firetail_config->FiretailEnabled = 0;
+  firetail_config->FiretailEnabled = NGX_CONF_UNSET;
 
   return firetail_config;
 }
@@ -49,6 +49,6 @@ void *CreateFiretailConfig(ngx_conf_t *configuration_object) {
 char *InitFiretailMainConfig(ngx_conf_t *configuration_object, void *http_main_config) { return NGX_CONF_OK; }
 
 char *MergeFiretailLocationConfig(ngx_conf_t *cf, void *parent, void *child) {
-  ngx_conf_merge_value(((FiretailConfig *)child)->FiretailEnabled, ((FiretailConfig *)parent)->FiretailEnabled, 0);
+  ngx_conf_merge_value(((FiretailConfig *)child)->FiretailEnabled, ((FiretailConfig *)parent)->FiretailEnabled, 1);
   return NGX_CONF_OK;
 }

--- a/src/nginx_module/firetail_context.c
+++ b/src/nginx_module/firetail_context.c
@@ -1,5 +1,4 @@
 #include <ngx_config.h>
-#include <ngx_core.h>
 #include <ngx_http.h>
 #include "access_phase_handler.h"
 #include "filter_headers.h"

--- a/src/nginx_module/firetail_directives.c
+++ b/src/nginx_module/firetail_directives.c
@@ -52,3 +52,13 @@ char *FiretailEnableDirectiveCallback(ngx_conf_t *configuration_object, ngx_comm
 
   return NGX_CONF_OK;
 }
+
+char *FiretailDisableDirectiveCallback(ngx_conf_t *configuration_object, ngx_command_t *command_definition,
+                                       void *http_main_config) {
+  // Find the firetail_enable_field given the config pointer & offset in cmd
+  char *firetail_config = http_main_config;
+  ngx_int_t *firetail_enabled_field = (ngx_int_t *)(firetail_config + command_definition->offset);
+  *firetail_enabled_field = 0;
+
+  return NGX_CONF_OK;
+}

--- a/src/nginx_module/firetail_directives.c
+++ b/src/nginx_module/firetail_directives.c
@@ -1,3 +1,4 @@
+#include <ngx_core.h>
 #include <ngx_http.h>
 
 char *FiretailApiTokenDirectiveCallback(ngx_conf_t *configuration_object, ngx_command_t *command_definition,

--- a/src/nginx_module/firetail_directives.h
+++ b/src/nginx_module/firetail_directives.h
@@ -10,8 +10,10 @@ char *FiretailAllowUndefinedRoutesDirectiveCallback(ngx_conf_t *configuration_ob
                                                     void *http_main_config);
 char *FiretailEnableDirectiveCallback(ngx_conf_t *configuration_object, ngx_command_t *command_definition,
                                       void *http_main_config);
+char *FiretailDisableDirectiveCallback(ngx_conf_t *configuration_object, ngx_command_t *command_definition,
+                                       void *http_main_config);
 
-ngx_command_t kFiretailCommands[5] = {
+ngx_command_t kFiretailCommands[6] = {
     {// Name of the directive
      ngx_string("firetail_api_token"),
      // Valid in the main config and takes one arg
@@ -41,4 +43,11 @@ ngx_command_t kFiretailCommands[5] = {
      // A callback function to be called when the directive is found in the
      // configuration
      FiretailEnableDirectiveCallback, NGX_HTTP_LOC_CONF_OFFSET, offsetof(FiretailConfig, FiretailEnabled), NULL},
+    {// Name of the directive
+     ngx_string("firetail_disable"),
+     // Valid in location configs and takes no args
+     NGX_HTTP_MAIN_CONF | NGX_CONF_NOARGS,
+     // A callback function to be called when the directive is found in the
+     // configuration
+     FiretailDisableDirectiveCallback, NGX_HTTP_LOC_CONF_OFFSET, offsetof(FiretailConfig, FiretailEnabled), NULL},
     ngx_null_command};

--- a/src/nginx_module/firetail_directives.h
+++ b/src/nginx_module/firetail_directives.h
@@ -1,5 +1,4 @@
 #include <ngx_core.h>
-#include <ngx_http.h>
 #include "firetail_config.h"
 
 char *FiretailApiTokenDirectiveCallback(ngx_conf_t *configuration_object, ngx_command_t *command_definition,

--- a/src/nginx_module/firetail_module.c
+++ b/src/nginx_module/firetail_module.c
@@ -1,14 +1,6 @@
-#include <ngx_config.h>
 #include <ngx_core.h>
-#include <ngx_http.h>
-#include "access_phase_handler.h"
-#include "filter_context.h"
-#include "filter_headers.h"
-#include "filter_response_body.h"
 #include "firetail_context.h"
 #include "firetail_directives.h"
-#include "firetail_module.h"
-#include <json-c/json.h>
 
 #define SIZE 65536
 

--- a/src/nginx_module/firetail_module.h
+++ b/src/nginx_module/firetail_module.h
@@ -1,6 +1,7 @@
 #ifndef FIRETAIL_MODULE_INCLUDED
 #define FIRETAIL_MODULE_INCLUDED
 
+#include <ngx_core.h>
 #include <ngx_http.h>
 
 // The header and body filters of the filter that was added just before ours.


### PR DESCRIPTION
## Describe your changes

Implements a `firetail_disable` directive which is currently only valid at the `http` block, which allows disabling FireTail by default so it is only enabled on locations which use the `firetail_enable` directive.

This can be expanded upon later so we could have `firetail_disable` in server or location blocks, and `firetail_enable` in server blocks too.

## Issue ticket number and link

https://firetail-io.atlassian.net/browse/FIRE-2909

## Checklist before requesting a review

-   [x] I have resolved any merge conflicts
-   [ ] I have run tests locally and they pass
-   [x] I have linted and auto-formatted the code
-   [ ] If there is new or changed functionality, I have added/updated the tests.
-   [ ] If there is new or changed functionality, I have added/updated the documentation.
